### PR TITLE
docs: streamline profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,8 @@ iOS Software Engineer · Los Angeles
 
 ## Toolbox
 <p align="left">
-<img src="https://skillicons.dev/icons?i=swift,swiftui,xcode,apple,firebase,gcp,python,git,github" />
+<img src="https://skillicons.dev/icons?i=swift,apple,git,github" />
 </p>
-
-- Frameworks: Swift Concurrency (async/await, `async let`), Combine, App Intents, Widgets, Live Activities, BackgroundTasks, SwiftData/Core Data, Cloud Functions.
-- Infra & QA: GitHub Actions, XCTest, Snapshot testing, SwiftLint, SwiftFormat.
-- Data: Firebase (Auth, Firestore, Remote Config), BigQuery, JSON over HTTPS.
 
 ### Stats & widgets
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
-## Hi there 👋
+<!-- Profile README for Ari -->
 
-<!--
-**ariiscoding/ariiscoding** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<div align="center">
 
-Here are some ideas to get you started:
+# Ari
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+iOS Software Engineer · Los Angeles
+
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-arihe-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/arihe/)
+![Visitors](https://komarev.com/ghpvc/?username=ariiscoding&color=blueviolet)
+
+</div>
+
+> Product‑minded iOS engineer focused on clean architecture, reliable shipping, and respectful privacy. I build with Swift, SwiftUI, and Firebase, and I like features that feel obvious in hindsight.
+
+## What I do
+- Leading the Memories iOS team at **Snap Inc.** Opinions are my own.
+- Running **henium**, a small mobile studio.
+- Interests: SwiftData, visionOS, Core ML on device, A/B with Remote Config, real‑time sync, DI with Factory, analytics with BigQuery.
+
+## Toolbox
+<p align="left">
+<img src="https://skillicons.dev/icons?i=swift,swiftui,xcode,apple,firebase,gcp,python,git,github" />
+</p>
+
+- Frameworks: Swift Concurrency (async/await, `async let`), Combine, App Intents, Widgets, Live Activities, BackgroundTasks, SwiftData/Core Data, Cloud Functions.
+- Infra & QA: GitHub Actions, XCTest, Snapshot testing, SwiftLint, SwiftFormat.
+- Data: Firebase (Auth, Firestore, Remote Config), BigQuery, JSON over HTTPS.
+
+### Stats & widgets
+<div align="center">
+
+<!-- Commit stats -->
+<img src="https://github-readme-stats.vercel.app/api?username=ariiscoding&show_icons=true&count_private=true&include_all_commits=true&hide_title=true" alt="GitHub stats" />
+
+<!-- Streak -->
+<img src="https://streak-stats.demolab.com?user=ariiscoding&hide_border=true" alt="GitHub streak" />
+
+<!-- Top languages -->
+<img src="https://github-readme-stats.vercel.app/api/top-langs/?username=ariiscoding&layout=compact&langs_count=8" alt="Top languages" />
+
+<!-- Trophies -->
+<img src="https://github-profile-trophy.vercel.app/?username=ariiscoding&margin-w=10" alt="Trophies" />
+
+</div>
+
+<!-- End -->


### PR DESCRIPTION
## Summary
- simplify profile README to focus on Snap role and interests
- remove metrics workflow and references pending API token

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a5ffa7448329be11215b05998027